### PR TITLE
AEO: add llms.txt and markdown docs #215

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const WebserialAdapter = require('chameleon-ultra.js/plugin/WebserialAdapter')
 
 ### CDN
 
-Using jsDelivr CDN:
+Powered by jsDelivr CDN:
 
 ```html
 <!-- script -->

--- a/llms-template.md
+++ b/llms-template.md
@@ -1,0 +1,79 @@
+{{header}}
+## quick start
+
+### install
+
+#### Package manager
+
+```shell
+# use npm
+npm install chameleon-ultra.js
+
+# use yarn
+yarn add chameleon-ultra.js
+```
+
+And then import the library using `import` or `require`:
+
+```js
+import { Buffer, ChameleonUltra } from 'chameleon-ultra.js'
+import WebbleAdapter from 'chameleon-ultra.js/plugin/WebbleAdapter'
+import WebserialAdapter from 'chameleon-ultra.js/plugin/WebserialAdapter'
+```
+
+#### CDN
+
+Powered by jsDelivr CDN:
+
+```html
+<!-- script -->
+<script src="https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/dist/index.global.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/dist/Crypto1.global.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/dist/plugin/WebbleAdapter.global.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/dist/plugin/WebserialAdapter.global.js"></script>
+<script>
+  const { Buffer, ChameleonUltra, WebbleAdapter, WebserialAdapter } = window.ChameleonUltraJS
+</script>
+
+<!-- module -->
+<script type="module">
+  import { Buffer, ChameleonUltra } from 'https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/+esm'
+  import WebbleAdapter from 'https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/plugin/WebbleAdapter/+esm'
+  import WebserialAdapter from 'https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/plugin/WebserialAdapter/+esm'
+</script>
+
+<!-- module + async import -->
+<script type="module">
+  const { Buffer, ChameleonUltra } = await import('https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/+esm')
+  const { default: WebbleAdapter } = await import('https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/plugin/WebbleAdapter/+esm')
+  const { default: WebserialAdapter } = await import('https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0/plugin/WebserialAdapter/+esm')
+</script>
+```
+
+### Register adapter
+
+The ChameleonUltra class requires exactly one adapter plugin to work. If you want to support both WebBLE and WebSerial, you can create two instances of ChameleonUltra and use different adapters for each instance.
+
+```js
+// For WebSerial and WebBluetooth
+const ultraUsb = new ChameleonUltra()
+ultraUsb.use(new WebserialAdapter())
+const ultraBle = new ChameleonUltra()
+ultraBle.use(new WebbleAdapter())
+
+// For Node.js with SerialPortAdapter
+const ultraNode = new ChameleonUltra()
+ultraNode.use(new SerialPortAdapter())
+```
+
+### Get the device Git version
+
+```js
+await (async ultra => {
+  console.log(await ultra.cmdGetGitVersion()) // 'v2.0.0-209-gc68ea99'
+})(ultraUsb) // or ultraBle, ultraNode
+```
+
+{{section:Guides}}
+
+{{declarations}}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "type-fest": "^5.4.4",
     "typedoc": "^0.28.17",
     "typedoc-plugin-ga": "^1.1.1",
+    "typedoc-plugin-llms-txt": "^0.1.2",
+    "typedoc-plugin-markdown": "^4.11.0",
     "typedoc-plugin-mdn-links": "^5.1.1",
     "typedoc-plugin-missing-exports": "^4.1.2",
     "typedoc-plugin-rename-defaults": "^0.7.3",

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,6 +5,8 @@
   "darkHighlightTheme": "dark-plus",
   "gaID": "G-KB8ZL6LPH5",
   "includeVersion": true,
+  "llmsTxtTemplate": "./llms-template.md",
+  "name": "chameleon-ultra.js",
   "out": "dist",
   "searchInComments": true,
   "searchInDocuments": true,
@@ -69,10 +71,12 @@
     "jsDelivr": "https://www.jsdelivr.com/package/npm/chameleon-ultra.js"
   },
   "plugin": [
+    "typedoc-plugin-ga",
+    "typedoc-plugin-llms-txt",
+    "typedoc-plugin-markdown",
     "typedoc-plugin-mdn-links",
     "typedoc-plugin-missing-exports",
-    "typedoc-plugin-rename-defaults",
-    "typedoc-plugin-ga"
+    "typedoc-plugin-rename-defaults"
   ],
   "projectDocuments": [
     "documents/*.md"
@@ -83,5 +87,19 @@
     "instance-first",
     "enum-value-ascending",
     "alphabetical-ignoring-documents"
+  ],
+  "llmsTxtSections": {
+    "Guides": { "displayName": "Documentation", "order": 1 },
+    "Reference": { "displayName": "Reference", "order": 2 },
+    "About": { "displayName": "Optional", "order": 3 }
+  },
+  "llmsTxtDeclarations": [
+    { "ref": "index!", "label": "index", "description": "index module" },
+    { "ref": "index!ChameleonUltra", "label": "index!ChameleonUltra", "description": "The core class to interact with the Chameleon Ultra device" },
+    { "ref": "plugin/Debug!", "label": "plugin/Debug", "description": "The Debug plugin for debugging purposes" },
+    { "ref": "plugin/DfuZip!", "label": "plugin/DfuZip", "description": "The DFUZip plugin for reading firmwares" },
+    { "ref": "plugin/SerialPortAdapter!", "label": "plugin/SerialPortAdapter", "description": "The Adapter plugin for connecting to device via Serial Port, used in Node.js environment" },
+    { "ref": "plugin/WebbleAdapter!", "label": "plugin/WebbleAdapter", "description": "The Adapter plugin for connecting to device via Web Bluetooth API, used in Chrome based browser of Windows/Linux/macOS/ChromeOS/Android and Bluefy browser of iPhone/iPad" },
+    { "ref": "plugin/WebserialAdapter!", "label": "plugin/WebserialAdapter", "description": "The Adapter plugin for connecting to device via Web Serial API, used in Chrome based browser of Windows/Linux/macOS" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6080,6 +6080,16 @@ typedoc-plugin-ga@^1.1.1:
   dependencies:
     "@euberdeveloper/eslint-plugin" "2.7.0"
 
+typedoc-plugin-llms-txt@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-llms-txt/-/typedoc-plugin-llms-txt-0.1.2.tgz#12d5950d31878cddf66509a70bc6683d1d46d49d"
+  integrity sha512-9q7x5ZdwkSZKJK23cvirtfQw87970n2p/hSv3T0YlOlgIY6isRHdUOM+QPErANFPXZv0X+ezS6QZp10dejOExQ==
+
+typedoc-plugin-markdown@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.11.0.tgz#57c29b0aeec2eba41e995670591de63bcf645b80"
+  integrity sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==
+
 typedoc-plugin-mdn-links@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-mdn-links/-/typedoc-plugin-mdn-links-5.1.1.tgz#1ef081b26ac3ab7e4f31d4be23d6e6a10551ede6"


### PR DESCRIPTION
This pull request adds support for generating LLMS-formatted documentation using TypeDoc plugins and introduces a new documentation template with improved quick start instructions. The changes primarily focus on enhancing the developer experience by providing clearer installation, usage, and adapter registration guides, as well as configuring TypeDoc to output LLMS and Markdown documentation.

**Documentation improvements:**

* Added a new `llms-template.md` file containing a comprehensive quick start guide, including installation instructions for npm/yarn, CDN usage, adapter registration, and example usage of the `ChameleonUltra` class and its adapters.
* Updated the CDN section in `README.md` to clarify that the project is "Powered by jsDelivr CDN".

**TypeDoc configuration and plugin integration:**

* Updated `typedoc.json` to specify the new LLMS template (`llms-template.md`), project name, and to configure LLMS-specific sections and declarations for improved documentation structure. [[1]](diffhunk://#diff-6169a21f84f4d19da38a12219c19778338487973f106b9dad94370e66e1c8c1aR8-R9) [[2]](diffhunk://#diff-6169a21f84f4d19da38a12219c19778338487973f106b9dad94370e66e1c8c1aL86-R104)
* Added new TypeDoc plugins (`typedoc-plugin-llms-txt`, `typedoc-plugin-markdown`) to `package.json` and `typedoc.json` for generating LLMS and Markdown documentation. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R77-R78) [[2]](diffhunk://#diff-6169a21f84f4d19da38a12219c19778338487973f106b9dad94370e66e1c8c1aR74-R79)