### PR TITLE
v0.4.5: fix mf1GenMagicBlock0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "./dist/index.mjs",
   "name": "chameleon-ultra.js",
   "type": "commonjs",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "bugs": {
     "url": "https://github.com/taichunmin/chameleon-ultra.js/issues"
   },

--- a/src/ChameleonUltra.test.ts
+++ b/src/ChameleonUltra.test.ts
@@ -1336,3 +1336,46 @@ test('calcUltraMaxItemSize()', async () => {
   expect(calcUltraMaxItemSize(6, 1024)).toBe(0)
   expect(calcUltraMaxItemSize(undefined, 10)).toBe(502)
 })
+
+test.each([
+  {
+    input: {
+      tagType: TagType.MIFARE_1024,
+      atqa: Buffer.of(0x04, 0x00),
+      sak: Buffer.of(0x08),
+      uid: Buffer.from('ABCDEF00', 'hex'),
+      buf: Buffer.from('00000000000000006263646566676869', 'hex'),
+    },
+    expected: Buffer.from('ABCDEF00890804006263646566676869', 'hex'),
+  },
+  {
+    input: {
+      uid: Buffer.from('ABCDEF00', 'hex'),
+    },
+    expected: Buffer.from('ABCDEF00890804000000000000000000', 'hex'),
+  },
+  {
+    input: {
+      tagType: TagType.MIFARE_1024,
+      uid: Buffer.from('04010203040506', 'hex'),
+    },
+    expected: Buffer.from('04010203040506884400c82000000000', 'hex'),
+  },
+  {
+    input: {
+      tagType: TagType.MIFARE_4096,
+      uid: Buffer.from('DEADBEEF', 'hex'),
+    },
+    expected: Buffer.from('deadbeef221802000000000000000000', 'hex'),
+  },
+  {
+    input: {
+      tagType: TagType.MIFARE_4096,
+      uid: Buffer.from('04010203040506', 'hex'),
+    },
+    expected: Buffer.from('04010203040506984200c82000000000', 'hex'),
+  },
+])('.mf1GenMagicBlock0({ uid: $input.uid })', ({ input, expected }) => {
+  const actual = ChameleonUltra.mf1GenMagicBlock0(input)
+  expect(actual.toString('hex')).toEqual(expected.toString('hex'))
+})

--- a/src/ChameleonUltra.ts
+++ b/src/ChameleonUltra.ts
@@ -29,6 +29,7 @@ import {
   type Hf14aRatsMode,
   HidProxFormat,
   HidProxFormatLimit,
+  Mf1AtqaSakDefaultMap,
   type Mf1EmuWriteMode,
   Mf1KeyType,
   type Mf1PrngType,
@@ -4442,6 +4443,7 @@ export class ChameleonUltra {
 
   /**
    * Generate block 0 (manufacturer block) for magic mifare classic tag.
+   * @param opts.tagType - The tag type of the mifare classic tag. Default to `MIFARE_1024`.
    * @param opts.atqa - The ATQA of the tag.
    * @param opts.buf - If provided, the data will be written to this buffer.
    * @param opts.sak - The SAK of the tag.
@@ -4479,37 +4481,27 @@ export class ChameleonUltra {
     buf?: Buffer
     sak?: Buffer
     uid: Buffer
+    tagType?: TagType
   }): Buffer {
+    opts.tagType ??= TagType.MIFARE_1024
+    if (!isTagType(opts.tagType)) throw new TypeError('Invalid tagType')
     const buf = opts.buf ?? new Buffer(16)
     if (!Buffer.isBuffer(buf) || buf.length < 16) throw new TypeError('Invalid buf')
     bufIsLenOrFail(opts.uid, [4, 7, 10], 'uid')
     if (!_.isNil(opts.sak)) bufIsLenOrFail(opts.sak, 1, 'sak')
     if (!_.isNil(opts.atqa)) bufIsLenOrFail(opts.atqa, 2, 'atqa')
 
-    switch (opts.uid.length) {
-      case 4:
-        // example: ABCDEF00890804006263646566676869
-        opts.sak ??= Buffer.of(0x08)
-        opts.atqa ??= Buffer.of(0x04, 0x00)
-        buf.set(opts.uid, 0)
-        buf[4] = buf.subarray(0, 4).xor()
-        buf[5] = opts.sak[0]
-        buf.set(opts.atqa, 6)
-        break
-      case 7:
-        // example: 04FE5572AA4880884400C82000000000
-        opts.sak ??= Buffer.of(0x88)
-        opts.atqa ??= Buffer.of(0x44, 0x00)
-        buf.set(opts.uid, 0)
-        buf[7] = opts.sak[0]
-        buf.set(opts.atqa, 8)
-        buf.set(Buffer.from('C82000000000', 'hex'), 10)
-        break
-      case 10:
-        throw new Error('10 bytes UID is not supported.')
-        // break
-    }
+    const atqaSak: [number[], number[]] | undefined = _.get(Mf1AtqaSakDefaultMap, [opts.uid.length, opts.tagType])
+    if (_.isNil(atqaSak)) throw new Error('Unable to generate magic block 0 for the given opts')
 
+    opts.atqa ??= Buffer.from(atqaSak[0])
+    opts.sak ??= Buffer.from(atqaSak[1])
+    if (opts.uid.length === 4) {
+      buf.pack('!4sBB2s', opts.uid, opts.uid.xor(), opts.sak[0], opts.atqa)
+    } else if (opts.uid.length === 7) {
+      opts.sak[0] |= 0x80
+      buf.pack('!7sB2s6s', opts.uid, opts.sak[0], opts.atqa, Buffer.from('C82000000000', 'hex'))
+    }
     return buf
   }
 
@@ -4552,17 +4544,6 @@ export class ChameleonUltra {
       case TagType.MIFARE_1024:
         opts.buf ??= new Buffer(1024)
         bufIsLenOrFail(opts.buf, 1024, 'buf')
-        if (opts.uid.length === 4) {
-          // M1-4B: atqa = 0x0400, sak = 0x08
-          opts.atqa ??= Buffer.of(0x04, 0x00)
-          opts.sak ??= Buffer.of(0x08)
-        } else if (opts.uid.length === 7) {
-          // M1-7B: atqa = 0x4400, sak = 0x88
-          opts.atqa ??= Buffer.of(0x44, 0x00)
-          opts.sak ??= Buffer.of(0x88)
-        } else if (opts.uid.length === 10) {
-          throw new Error('10 bytes UID is not supported.')
-        }
         ChameleonUltra.mf1GenMagicBlock0(opts as any)
         for (let i = 0; i < 16; i++) opts.buf.set(blkAcl, i * 64 + 48) // block 4n+3
         return opts.buf
@@ -4570,17 +4551,6 @@ export class ChameleonUltra {
       case TagType.MIFARE_2048:
         opts.buf ??= new Buffer(2048)
         bufIsLenOrFail(opts.buf, 2048, 'buf')
-        if (opts.uid.length === 4) {
-          // M1-4B: atqa = 0x0400, sak = 0x08
-          opts.atqa ??= Buffer.of(0x04, 0x00)
-          opts.sak ??= Buffer.of(0x08)
-        } else if (opts.uid.length === 7) {
-          // M1-7B: atqa = 0x4400, sak = 0x88
-          opts.atqa ??= Buffer.of(0x44, 0x00)
-          opts.sak ??= Buffer.of(0x88)
-        } else if (opts.uid.length === 10) {
-          throw new Error('10 bytes UID is not supported.')
-        }
         ChameleonUltra.mf1GenMagicBlock0(opts as any)
         for (let i = 0; i < 32; i++) opts.buf.set(blkAcl, i * 64 + 48) // block 4n+3
         return opts.buf
@@ -4588,9 +4558,6 @@ export class ChameleonUltra {
       case TagType.MIFARE_4096:
         opts.buf ??= new Buffer(4096)
         bufIsLenOrFail(opts.buf, 4096, 'buf')
-        // TODO: need to confirm atqa and sak of M1-4K-7B
-        opts.atqa ??= Buffer.of(0x02, 0x00)
-        opts.sak ??= Buffer.of(0x18)
         ChameleonUltra.mf1GenMagicBlock0(opts as any)
         for (let i = 0; i < 32; i++) opts.buf.set(blkAcl, i * 64 + 48) // block 4n+3
         for (let i = 32; i < 40; i++) opts.buf.set(blkAcl, i * 256 - 5904) // block 16n+15

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -722,6 +722,21 @@ export const HidProxFormatName = new Map<HidProxFormat, string>([
   [HidProxFormat.MDI37, 'PointGuard MDI 37-bit'],
 ])
 
+export const Mf1AtqaSakDefaultMap = {
+  4: {
+    [TagType.MIFARE_Mini]: [[0x04, 0x00], [0x09]],
+    [TagType.MIFARE_1024]: [[0x04, 0x00], [0x08]], // example: ABCDEF00 89 08 0400 6263646566676869
+    [TagType.MIFARE_2048]: [[0x04, 0x00], [0x08]],
+    [TagType.MIFARE_4096]: [[0x02, 0x00], [0x18]],
+  },
+  7: {
+    [TagType.MIFARE_Mini]: [[0x44, 0x00], [0x09]],
+    [TagType.MIFARE_1024]: [[0x44, 0x00], [0x08]], // example: 04FE5572AA4880 88 4400 C82000000000
+    [TagType.MIFARE_2048]: [[0x44, 0x00], [0x08]],
+    [TagType.MIFARE_4096]: [[0x42, 0x00], [0x18]],
+  },
+} as const
+
 export const MfuVerToNxpMfuType = new Map([
   ['0004030101000B', NxpMfuType.UL_EV1_48],
   ['0004030101000E', NxpMfuType.UL_EV1_128],


### PR DESCRIPTION
This pull request refactors and improves the logic for generating MIFARE Classic magic block 0, making it more robust and maintainable. The main change is the introduction of a centralized mapping for default ATQA and SAK values based on tag type and UID length, which reduces code duplication and potential errors. Additionally, comprehensive tests have been added to ensure correctness.

**Refactoring and logic improvements:**

* Introduced the `Mf1AtqaSakDefaultMap` in `enums.ts` to centralize default `ATQA` and `SAK` values for different `TagType` and UID lengths, replacing hardcoded values in multiple locations.
* Updated `mf1GenMagicBlock0` in `ChameleonUltra.ts` to use `Mf1AtqaSakDefaultMap` for determining defaults and improved validation of `tagType` and buffer arguments. This also simplifies the logic and improves error handling for unsupported UID lengths.
* Refactored `mf1GenMagicBlock` to remove redundant default assignments for `ATQA` and `SAK`, delegating this responsibility to the improved `mf1GenMagicBlock0`.
* Updated documentation for `mf1GenMagicBlock0` to include the new `tagType` parameter.
* Added import for `Mf1AtqaSakDefaultMap` in `ChameleonUltra.ts`.

**Testing improvements:**

* Added parameterized tests for `mf1GenMagicBlock0` to verify correct block generation for various combinations of UID, tag type, and optional parameters.

**Other:**

* Bumped package version from `0.4.4` to `0.4.5` in `package.json`.