### PR TITLE
fix mfkey32 with 7 bytes UID

### DIFF
--- a/pug/src/mfkey32-v1.pug
+++ b/pug/src/mfkey32-v1.pug
@@ -203,7 +203,7 @@ block script
             const tag = {
               atqa: Buffer.from(atqa, 'hex').reverse(),
               sak: Buffer.from(sak, 'hex'),
-              uid: Buffer.from(uid, 'hex').slice(-4),
+              uid: Buffer.from(uid, 'hex'),
             }
             await ultra.cmdMf1SetAntiCollMode(false)
             await ultra.cmdHf14aSetAntiCollData(tag)

--- a/pug/src/mfkey32.pug
+++ b/pug/src/mfkey32.pug
@@ -482,7 +482,7 @@ block script
               atqa: Buffer.from(atqa, 'hex').toReversed(),
               ats: Buffer.from(ats, 'hex'),
               sak: Buffer.from(sak, 'hex'),
-              uid: Buffer.from(uid, 'hex').slice(-4),
+              uid: Buffer.from(uid, 'hex'),
             }
             await ultra.cmdMf1SetAntiCollMode(false)
             await ultra.cmdHf14aSetAntiCollData(tag)


### PR DESCRIPTION
This pull request updates the way tag UIDs are handled in both `mfkey32-v1.pug` and `mfkey32.pug` scripts. Previously, only the last 4 bytes of the UID were used; now, the full UID is included. This change ensures that the entire UID is processed, which may improve compatibility with tags that use longer UIDs.

**UID Handling Updates:**

* Changed UID processing to use the full UID instead of only the last 4 bytes in `mfkey32-v1.pug`.
* Changed UID processing to use the full UID instead of only the last 4 bytes in `mfkey32.pug`.