### PR TITLE
ignore error of purge jsdelivr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
       - name: jsDelivr Purge
         uses: egad13/purge-jsdelivr-cache@v1
         if: ${{ steps.npm-publish.outputs.type }}
+        continue-on-error: true
         with:
           url: |
             https://cdn.jsdelivr.net/npm/chameleon-ultra.js@0


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration. The change allows the jsDelivr purge step to continue even if it encounters an error, which can help prevent workflow failures due to issues with the CDN purge.

- CI/CD workflow improvement:
  * Added `continue-on-error: true` to the `jsDelivr Purge` step in `.github/workflows/ci.yml` to prevent workflow failures if the purge fails.