### PR TITLE
Add Context7 chat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 ![](https://i.imgur.com/bWJGSGq.png)
 
+<script src="https://context7.com/widget.js" data-library="/llmstxt/taichunmin_idv_tw_chameleon-ultra_js_llms_txt"></script>
+
 ## Browser & OS compatibility
 
 ### SerialPort (Node.js)


### PR DESCRIPTION
This pull request adds an external script to the `README.md` for embedding a widget. The change is minor and only affects the documentation. 

- Documentation update:
  * Added a `<script>` tag to include an external widget from `context7.com` in the `README.md`.