### PR TITLE
Add Context7 chat integration to HTML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@
 
 ![](https://i.imgur.com/bWJGSGq.png)
 
-<script src="https://context7.com/widget.js" data-library="/llmstxt/taichunmin_idv_tw_chameleon-ultra_js_llms_txt"></script>
-
 ## Browser & OS compatibility
 
 ### SerialPort (Node.js)

--- a/build-utils/typedoc.ts
+++ b/build-utils/typedoc.ts
@@ -1,7 +1,10 @@
-import { fileURLToPath } from 'url'
+import fg from 'fast-glob'
 import fsPromises from 'fs/promises'
 import JSON5 from 'json5'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const CONTEXT7_SCRIPT = '<script src="https://context7.com/widget.js" data-library="/llmstxt/taichunmin_idv_tw_chameleon-ultra_js_llms_txt"></script>'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url)) // eslint-disable-line @typescript-eslint/naming-convention
 
@@ -11,17 +14,34 @@ async function main (): Promise<void> {
   const verFiles = [
     '../dist/variables/index.version.html',
   ]
-  for (let file of verFiles) {
+  for (let filepath of verFiles) {
     try {
-      file = path.resolve(__dirname, file)
-      let content = await fsPromises.readFile(file, 'utf8')
+      filepath = path.resolve(__dirname, filepath)
+      let content = await fsPromises.readFile(filepath, 'utf8')
       content = content.replace(/ = [.]{3}/g, ` = &#39;${pkg.version}&#39;`)
-      await fsPromises.writeFile(file, content, 'utf8')
+      await fsPromises.writeFile(filepath, content, 'utf8')
     } catch (err) {
-      err.message = `${err.message}, file: ${file}`
+      err.message = `${err.message}, filepath: ${filepath}`
       console.error(err)
     }
   }
+
+  // Add Context7 chat integration
+  let context7AddedCnt = 0
+  for (let filepath of await fg('../dist/**/*.html', { cwd: __dirname })) {
+    try {
+      filepath = path.resolve(__dirname, filepath)
+      let content = await fsPromises.readFile(filepath, 'utf8')
+      if (content.includes(CONTEXT7_SCRIPT)) continue
+      content = content.replace('</body>', `${CONTEXT7_SCRIPT}</body>`)
+      await fsPromises.writeFile(filepath, content, 'utf8')
+      context7AddedCnt++
+    } catch (err) {
+      err.message = `${err.message}, filepath: ${filepath}`
+      console.error(err)
+    }
+  }
+  console.log(`Added Context7 chat integration to ${context7AddedCnt} files`)
 }
 
 main().catch(err => {


### PR DESCRIPTION
This pull request adds automated integration of the Context7 chat widget into all generated HTML files and improves error handling in the build script. It also removes a previously hardcoded script tag from the `README.md` to avoid redundancy.

**Build process improvements:**

* [`build-utils/typedoc.ts`](diffhunk://#diff-496e21e4ec82e9a01650b8e432386c4d4a22326eec557d752a761c0a7e83c20aR2-R8): Adds a step to automatically insert the Context7 chat widget script into all HTML files in the `dist` directory, ensuring consistent integration across the documentation. [[1]](diffhunk://#diff-496e21e4ec82e9a01650b8e432386c4d4a22326eec557d752a761c0a7e83c20aR2-R8) [[2]](diffhunk://#diff-496e21e4ec82e9a01650b8e432386c4d4a22326eec557d752a761c0a7e83c20aL14-R44)
* [`build-utils/typedoc.ts`](diffhunk://#diff-496e21e4ec82e9a01650b8e432386c4d4a22326eec557d752a761c0a7e83c20aL14-R44): Improves error handling by logging file paths when read/write operations fail, making debugging easier.

**Documentation update:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-L29): Removes the hardcoded Context7 chat widget script tag, as the integration is now handled automatically during the build process.