### PR TITLE
Add Context7 chat integration

### DIFF
--- a/build-utils/sitemap.ts
+++ b/build-utils/sitemap.ts
@@ -1,13 +1,16 @@
 import { getSiteurl } from '../pug/dotenv'
 
-import * as _ from 'lodash-es'
-import { fileURLToPath } from 'url'
-import { promises as fsPromises } from 'fs'
 import dayjs from 'dayjs'
 import fg from 'fast-glob'
+import { promises as fsPromises } from 'fs'
+import * as _ from 'lodash-es'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url)) // eslint-disable-line @typescript-eslint/naming-convention
+
+const CONTEXT7_SCRIPT = '<script src="https://context7.com/widget.js" data-library="/llmstxt/taichunmin_idv_tw_chameleon-ultra_js_llms_txt"></script>'
+const OG_IMAGE_META = '<meta property="og:image" content="https://i.imgur.com/bWJGSGq.png"><meta property="og:image:width" content="1280"><meta property="og:image:height" content="640"></head>'
 
 function toUrl (url: string): string {
   url = url.replace(/[/]index[.]html$/, '/')
@@ -54,14 +57,36 @@ export async function build (): Promise<void> {
   // og:image
   let ogImageAddedCnt = 0
   for (const filepath of await fg('../dist/**/*.html', { cwd: __dirname })) {
-    const filepath1 = path.resolve(__dirname, filepath)
-    let content = await fsPromises.readFile(filepath1, 'utf8')
-    if (content.includes('property="og:image"')) continue
-    content = content.replace('</head>', '<meta property="og:image" content="https://i.imgur.com/bWJGSGq.png"><meta property="og:image:width" content="1280"><meta property="og:image:height" content="640"></head>')
-    await fsPromises.writeFile(filepath1, content, 'utf8')
-    ogImageAddedCnt++
+    try {
+      const filepath1 = path.resolve(__dirname, filepath)
+      let content = await fsPromises.readFile(filepath1, 'utf8')
+      if (content.includes('property="og:image"')) continue
+      content = content.replace('</head>', OG_IMAGE_META)
+      await fsPromises.writeFile(filepath1, content, 'utf8')
+      ogImageAddedCnt++
+    } catch (err) {
+      err.message = `${err.message}, filepath: ${filepath}`
+      console.error(err)
+    }
   }
   console.log(`Added og:image to ${ogImageAddedCnt} files`)
+
+  // Add Context7 chat integration
+  let context7AddedCnt = 0
+  for (let filepath of await fg('../dist/**/*.html', { cwd: __dirname })) {
+    try {
+      filepath = path.resolve(__dirname, filepath)
+      let content = await fsPromises.readFile(filepath, 'utf8')
+      if (content.includes(CONTEXT7_SCRIPT)) continue
+      content = content.replace('</body>', `${CONTEXT7_SCRIPT}</body>`)
+      await fsPromises.writeFile(filepath, content, 'utf8')
+      context7AddedCnt++
+    } catch (err) {
+      err.message = `${err.message}, filepath: ${filepath}`
+      console.error(err)
+    }
+  }
+  console.log(`Added Context7 chat integration to ${context7AddedCnt} files`)
 }
 
 build().catch(err => {

--- a/build-utils/typedoc.ts
+++ b/build-utils/typedoc.ts
@@ -1,7 +1,7 @@
-import { fileURLToPath } from 'url'
 import fsPromises from 'fs/promises'
 import JSON5 from 'json5'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url)) // eslint-disable-line @typescript-eslint/naming-convention
 
@@ -11,14 +11,14 @@ async function main (): Promise<void> {
   const verFiles = [
     '../dist/variables/index.version.html',
   ]
-  for (let file of verFiles) {
+  for (let filepath of verFiles) {
     try {
-      file = path.resolve(__dirname, file)
-      let content = await fsPromises.readFile(file, 'utf8')
+      filepath = path.resolve(__dirname, filepath)
+      let content = await fsPromises.readFile(filepath, 'utf8')
       content = content.replace(/ = [.]{3}/g, ` = &#39;${pkg.version}&#39;`)
-      await fsPromises.writeFile(file, content, 'utf8')
+      await fsPromises.writeFile(filepath, content, 'utf8')
     } catch (err) {
-      err.message = `${err.message}, file: ${file}`
+      err.message = `${err.message}, filepath: ${filepath}`
       console.error(err)
     }
   }


### PR DESCRIPTION
This pull request updates build utility scripts to improve maintainability and add new features to the static site generation process. The most important changes include adding automatic injection of Open Graph image metadata and Context7 chat integration into generated HTML files, as well as minor code refactoring for clarity and consistency.

### New features for HTML generation

* Automatically injects Open Graph image metadata (`og:image`) into HTML files during the build process, using a constant for the injected HTML to ensure consistency and maintainability. [[1]](diffhunk://#diff-a263546c9cea36fb62da6e401b5efa2e52257f21ca510fd6322216a0e890f34fL3-R14) [[2]](diffhunk://#diff-a263546c9cea36fb62da6e401b5efa2e52257f21ca510fd6322216a0e890f34fL60-R84)
* Adds Context7 chat widget integration by injecting the required script tag into all generated HTML files, with safeguards to avoid duplicate insertion and error handling for robustness. [[1]](diffhunk://#diff-a263546c9cea36fb62da6e401b5efa2e52257f21ca510fd6322216a0e890f34fL3-R14) [[2]](diffhunk://#diff-a263546c9cea36fb62da6e401b5efa2e52257f21ca510fd6322216a0e890f34fL60-R84)

### Code refactoring and cleanup

* Refactors variable names in `build-utils/typedoc.ts` for clarity (e.g., `file` to `filepath`) and improves error messages to include the affected file path.
* Reorders and standardizes import statements in both `build-utils/sitemap.ts` and `build-utils/typedoc.ts` for consistency and better readability. [[1]](diffhunk://#diff-a263546c9cea36fb62da6e401b5efa2e52257f21ca510fd6322216a0e890f34fL3-R14) [[2]](diffhunk://#diff-496e21e4ec82e9a01650b8e432386c4d4a22326eec557d752a761c0a7e83c20aL1-R4)